### PR TITLE
Periods aren't valid in metric names, so replace with underscores

### DIFF
--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -13,10 +13,10 @@ from prometheus_es_exporter.parser import parse_response
 gauges = {}
 
 def format_label_value(value_list):
-    return '_'.join(value_list)
+    return '_'.join(value_list).replace('.', '_')
 
 def format_metric_name(name_list):
-    return '_'.join(name_list)
+    return '_'.join(name_list).replace('.', '_')
 
 def update_gauges(metrics):
     metric_dict = {}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='prometheus-es-exporter',
-    version='0.1.1',
+    version='0.1.2',
     description='Elasticsearch query Prometheus exporter',
     url='https://github.com/Braedon/prometheus-es-exporter',
     author='Braedon Vickers',


### PR DESCRIPTION
Metric names generated from ES results may have periods in them (e.g. the
percentiles aggregation). This solution also silently replaces periods in
user-selected parts of metric names, but that's not a disastrous
side-effect for a much simpler implementation.

There will be other characters that are invalid in metric names, but lets
ignore them unless we find a ES query that generates them.