### PR TITLE
Set query-based gauges to zero after es_client exception

### DIFF
--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -90,6 +90,9 @@ def update_gauges(metrics):
 
         gauges[metric_name] = (new_label_values_set, gauge)
 
+def zero_gauges():
+    for metric_name, (new_label_values_set, gauge) in gauges.items():
+        gauge.set(0)
 
 def gauge_generator(metrics):
     metric_dict = group_metrics(metrics)
@@ -117,6 +120,7 @@ def run_query(es_client, name, indices, query, timeout):
         metrics = parse_response(response, [name])
     except Exception:
         logging.exception('Error while querying indices [%s], query [%s].', indices, query)
+        zero_gauges()
     else:
         update_gauges(metrics)
 


### PR DESCRIPTION
I suggest to set query-based gauges to zero after es_client exception (or, maybe, just index_not_found).

Now when we got metrics from daily indexes generated by filebeat and this day there are no logs and filebeat doesn't yet create log index then exporter would got exception and leave query gauges at values of previous day. 

I think it's not correct in every cases and we should have chance to set behavior (leave gauges as is or set it to zero).