### PR TITLE
Add the `--config-dir` option

### DIFF
--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -306,7 +306,7 @@ def main():
     parser.add_argument('-c', '--config-file', default='exporter.cfg',
                         help='path to query config file. Can be absolute, or relative to the current working directory. (default: exporter.cfg)')
     parser.add_argument('--config-dir', default='./config',
-                        help='path to query config directory. All config files in the directory will be included. Can be absolute, or relative to the current working directory. (default: ./config)')
+                        help='path to query config directory. Besides including the single config file specified by "--config-file" at first, all config files in the config directory will be sorted, merged, then included. Can be absolute, or relative to the current working directory. (default: ./config)')
     parser.add_argument('--cluster-health-disable', action='store_true',
                         help='disable cluster health monitoring.')
     parser.add_argument('--cluster-health-timeout', type=float, default=10.0,
@@ -373,7 +373,9 @@ def main():
 
         config = configparser.ConfigParser()
         config.read_file(open(args.config_file))
-        config.read(glob.glob('{}/*.cfg'.format(args.config_dir)))
+
+        config_dir_sorted_files = sorted(glob.glob(os.path.join(args.config_dir, '*.cfg')))
+        config.read(config_dir_sorted_files)
 
         query_prefix = 'query_'
         queries = {}

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import configparser
+import glob
 import json
 import logging
 import re
@@ -304,6 +305,8 @@ def main():
                         help='disable query monitoring. Config file does not need to be present if query monitoring is disabled.')
     parser.add_argument('-c', '--config-file', default='exporter.cfg',
                         help='path to query config file. Can be absolute, or relative to the current working directory. (default: exporter.cfg)')
+    parser.add_argument('--config-dir', default='./config',
+                        help='path to query config directory. All config files in the directory will be included. Can be absolute, or relative to the current working directory. (default: ./config)')
     parser.add_argument('--cluster-health-disable', action='store_true',
                         help='disable cluster health monitoring.')
     parser.add_argument('--cluster-health-timeout', type=float, default=10.0,
@@ -370,6 +373,7 @@ def main():
 
         config = configparser.ConfigParser()
         config.read_file(open(args.config_file))
+        config.read(glob.glob(f'{args.config_dir}/*.cfg'))
 
         query_prefix = 'query_'
         queries = {}

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -373,7 +373,7 @@ def main():
 
         config = configparser.ConfigParser()
         config.read_file(open(args.config_file))
-        config.read(glob.glob(f'{args.config_dir}/*.cfg'))
+        config.read(glob.glob('{}/*.cfg'.format(args.config_dir)))
 
         query_prefix = 'query_'
         queries = {}


### PR DESCRIPTION
With `--config-dir` option, it allows the configuration to be seperated
into multiple files.
In the case if you don't want to put all query in the same configuration
file, it would support this kind of configuration files tructure.

```
├── default.cfg
└── config
    ├── query1.cfg
    ├── query2.cfg
    └── query3.cfg
```