### PR TITLE
Add Helm chart to repository

### DIFF
--- a/helm/prometheus-es-exporter/.helmignore
+++ b/helm/prometheus-es-exporter/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/prometheus-es-exporter/Chart.yaml
+++ b/helm/prometheus-es-exporter/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+description: Launch queries to elasticsearch and renderize them as prometheus metrics.
+name: prometheus-es-exporter
+version: 0.0.1
+appVersion: "1.0"
+home: https://github.com/braedon/prometheus-es-exporter
+maintainers:
+  - name: Alex Perez-Pujol
+    email: alexperezpujol@disroot.org

--- a/helm/prometheus-es-exporter/README.md
+++ b/helm/prometheus-es-exporter/README.md
@@ -1,0 +1,115 @@
+# prometheus-es-exporter
+
+[prometheus-es-exporter](https://github.com/braedon/prometheus-es-exporter) is a
+prometheus exporter that collects metrics from queries run on an Elasticsearch
+cluster's data, and metrics about the cluster itself.
+
+## TL;DR;
+
+```bash
+helm install stable/prometheus-es-explorer --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+## Introduction
+
+This chart bootstraps a prometheus elasticsearch queries exporter deployment on a
+[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh)
+package manager.
+
+## Prerequisites
+  - Kubernetes 1.9+
+  - Prometheus operator (if you want to use the ServiceMonitor)
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install --name my-release stable/prometheus-es-exporter --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+The command deploys nginx-ingress on the Kubernetes cluster in the default
+configuration. The [configuration](#configuration) section lists the parameters
+that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and
+deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the nginx-ingress chart and their default values.
+
+Parameter | Description | Default
+--- | --- | ---
+`elasticsearch.url` | elasticsearch endpoint, with the port included | none
+`elasticsearch.queries` | elasticsearch queries to make | none
+`prometheus.serviceMonitor` | if set to `true`, will create a ServiceMonitor | `false`
+`prometheus.name` | label name of the prometheus instance used | none
+`image.repository` | prometheus-es-exporter container image repository | `braedon/prometheus-es-exporter`
+`image.tag` | prometheus-es-exporter container image tag | `0.5.1`
+`image.pullPolicy` | prometheus-es-exporter container image pull policy | `IfNotPresent`
+`tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`affinity` | node/pod affinities (requires Kubernetes >=1.6) | `{}`
+`nodeSelector` | node labels for pod assignment | `{}`
+`resources` | controller pod resource requests & limits | `{}`
+`service.type` | type of controller service to create | `ClusterIp`
+`service.port` | port in which the service will be listening | `9206`
+
+```bash
+helm install stable/prometheus-es-exporter --name my-release \
+    --set elasticsearch.url="http://elasticsearch:9200"
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be
+provided while installing the chart. For example:
+
+```bash
+helm install stable/prometheus-es-exporter --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+## Tests
+### Integration tests
+Two tests will be run. One will test that the service is really pointing to the
+pod and the other will only be run if `prometheus.serviceMonitor` is enabled,
+and will test if there are metrics in prometheus. You may execute them like this:
+
+```bash
+helm test my-release --cleanup
+```
+
+```console
+RUNNING: my-release-servicemonitor-test
+PASSED: my-release-servicemonitor-test
+RUNNING: my-release-service-test
+PASSED: my-release-service-test
+```
+
+### Unittests
+There's some unittests done with the
+![helm-unittests](https://github.com/lrills/helm-unittest) plugin. You may check
+it's page to install the plugin. You may execute them like this:
+
+```bash
+helm unittest -f templates/tests/unittest-deployment.yaml -f \
+    `templates/tests/unittest-servicemonitor.yaml .
+```
+```console
+### Chart [ prometheus-es-exporter ] .
+ PASS  test deployment	templates/tests/unittest-deployment.yaml
+ PASS  test servicemonitor	templates/tests/unittest-servicemonitor.yaml
+Charts:      1 passed, 1 total
+Test Suites: 2 passed, 2 total
+Tests:       11 passed, 11 total
+Snapshot:    0 passed, 0 total
+Time:        14.940903ms
+```

--- a/helm/prometheus-es-exporter/templates/NOTES.txt
+++ b/helm/prometheus-es-exporter/templates/NOTES.txt
@@ -1,0 +1,12 @@
+{{- if eq (printf "%s" .Values.elasticsearch.url ) "" }}
+########################################################
+####   ERROR: You did not set an elasticsearch url. ####
+########################################################
+
+This deployment will be incomplete until you set the elasticsearch url:
+
+    helm upgrade {{ .Release.Name }} \
+        --set elasticsearch.url="http://elasticsearch:9200" stable/prometheus-es-exporter
+{{- else -}}
+If you created a ServiceMonitor, it may take a while for prometheus to ingest the metrics.
+{{end}}

--- a/helm/prometheus-es-exporter/templates/_helpers.tpl
+++ b/helm/prometheus-es-exporter/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-es-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-es-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-es-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/prometheus-es-exporter/templates/configmap.yaml
+++ b/helm/prometheus-es-exporter/templates/configmap.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.elasticsearch.queries }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  exporter.cfg: |
+{{ .Values.elasticsearch.queries | indent 4 }}
+{{- end }}

--- a/helm/prometheus-es-exporter/templates/deployment.yaml
+++ b/helm/prometheus-es-exporter/templates/deployment.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "prometheus-es-exporter.fullname" . }}
+  labels:
+    app: {{ include "prometheus-es-exporter.name" . }}
+    chart: {{ include "prometheus-es-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "9206"
+      labels:
+        app: {{ include "prometheus-es-exporter.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-p"
+            - "{{ .Values.service.port }}"
+            - "-e"
+            - "{{ required "A valid .Values.elasticsearch.url entry required!" .Values.elasticsearch.url }}"
+           {{- if not .Values.elasticsearch.queries }}
+            - "--query-disable"
+           {{- end }}
+           {{- if .Values.containerExtraArgs }}
+           {{- range .Values.containerExtraArgs }}
+            - {{ . }}
+           {{- end }}
+           {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          volumeMounts:
+            - mountPath: /usr/src/app/exporter.cfg
+              subPath: "exporter.cfg"
+              name: {{ include "prometheus-es-exporter.fullname" . }}
+{{ if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+{{ end }}
+      volumes:
+        - name: {{ include "prometheus-es-exporter.fullname" . }}
+          configMap:
+            name: {{ include "prometheus-es-exporter.fullname" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm/prometheus-es-exporter/values.yaml
+++ b/helm/prometheus-es-exporter/values.yaml
@@ -1,0 +1,57 @@
+---
+# Default values for prometheus-es-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+elasticsearch:
+  url: ""
+  queries: ""
+#     Example:
+#     [DEFAULT]
+#     QueryIntervalSecs = 15
+#     QueryTimeoutSecs = 10
+#     QueryIndices = _all
+
+#     [query_all]
+#     QueryJson = {
+#     "size": 0,
+#     "query": {
+#       "match_all": {}
+#       }
+#     }
+
+containerExtraArgs: ""
+
+prometheus:
+  serviceMonitor: false
+  serviceMonitorInterval: 60s
+  name: ""
+
+replicaCount: 1
+
+image:
+  repository: braedon/prometheus-es-exporter
+  tag: 0.5.2
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9206
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
I've added the great work made by @alexpg in` /helm`. (see [issue](https://github.com/braedon/prometheus-es-exporter/issues/32))

This [other PR](https://github.com/helm/charts/pull/11871) to add it to the stable helm repository has been dismissed, and I think this work should be available from this repo. 

The code is exactly the same from that PR, didn't change anything. I can maintain this helm chart if you wish.