### PR TITLE
Configure how metrics are handled on error and when metrics go missing

### DIFF
--- a/exporter.cfg
+++ b/exporter.cfg
@@ -10,6 +10,17 @@ QueryTimeoutSecs = 10
 # The indices to run the query on.
 # Any way of specifying indices supported by your Elasticsearch version can be used.
 QueryIndices = _all
+# What to do if a query throws an error. One of:
+# * preserve - keep the metrics/values from the last successful run.
+# * drop - remove metrics previously produced by the query.
+# * zero - keep metrics previously produced by the query, but reset their values to 0.
+QueryOnError = drop
+# What to do if a metric produced by the previous run of a query is not present
+# in the current run. One of:
+# * preserve - keep the value of the metric from the last run it was present in.
+# * drop - remove the metric.
+# * zero - keep the metric, but reset its value to 0.
+QueryOnMissing = drop
 
 # Queries are defined in sections beginning with 'query_'.
 # Characters following this prefix will be used as a prefix for all metrics
@@ -29,6 +40,8 @@ QueryJson = {
 QueryIntervalSecs = 20
 QueryTimeoutSecs = 15
 QueryIndices = <logstash-{now/d}>
+QueryOnError = preserve
+QueryOnMissing = zero
 QueryJson = {
         "size": 0,
         "query": {

--- a/prometheus_es_exporter/metrics.py
+++ b/prometheus_es_exporter/metrics.py
@@ -111,21 +111,75 @@ def group_metrics(metrics):
     return metric_dict
 
 
-def gauge_generator(metrics):
+def merge_value_dicts(old_value_dict, new_value_dict, zero_missing=False):
+    """
+    Merge an old and new value dict together, returning the merged value dict.
+
+    Value dicts map from label values tuple -> metric value.
+
+    Values from the new value dict have precidence. If any label values tuples
+    from the old value dict are not present in the new value dict and
+    zero_missing is set, their values are reset to zero.
+    """
+    value_dict = new_value_dict.copy()
+    value_dict.update({
+        label_values: 0 if zero_missing else old_value
+        for label_values, old_value
+        in old_value_dict.items()
+        if label_values not in new_value_dict
+    })
+    return value_dict
+
+
+def merge_metric_dicts(old_metric_dict, new_metric_dict, zero_missing=False):
+    """
+    Merge an old and new metric dict together, returning the merged metric dict.
+
+    Metric dicts are keyed by metric name. Each metric name maps to a tuple
+    containing:
+    * metric documentation
+    * label keys tuple,
+    * dict of label values tuple -> metric value.
+
+    Values from the new metric dict have precidence. If any metric names from
+    the old metric dict are not present in the new metric dict and zero_missing
+    is set, their values are reset to zero.
+
+    Merging (and missing value zeroing, if set) is performed on the value dicts
+    for each metric, not just on the top level metrics themselves.
+    """
+    metric_dict = new_metric_dict.copy()
+    metric_dict.update({
+        metric_name: (
+            metric_doc,
+            label_keys,
+            merge_value_dicts(
+                old_value_dict,
+                new_value_dict=new_metric_dict[metric_name][2]
+                if metric_name in new_metric_dict else None,
+                zero_missing=zero_missing
+            )
+        )
+        for metric_name, (metric_doc, label_keys, old_value_dict)
+        in old_metric_dict.items()
+    })
+    return metric_dict
+
+
+def gauge_generator(metric_dict):
     """
     Generates GaugeMetricFamily instances for a list of metrics.
 
-    Takes metrics as a list of tuples containing:
-    * metric name,
-    * metric documentation,
-    * dict of label key -> label value,
-    * metric value.
+    Takes metrics as a dict keyed by metric name. Each metric name maps to a
+    tuple containing:
+    * metric documentation
+    * label keys tuple,
+    * dict of label values tuple -> metric value.
 
     Yields a GaugeMetricFamily instance for each unique metric name, containing
     children for the various label combinations. Suitable for use in a collect()
     method of a Prometheus collector.
     """
-    metric_dict = group_metrics(metrics)
 
     for metric_name, (metric_doc, label_keys, value_dict) in metric_dict.items():
         # If we have label keys we may have multiple different values,


### PR DESCRIPTION
When an error is encountered running a query, the query's metrics will be
dropped by default. Queries can be configured to preserve the old
metrics/values instead, or preserve the metrics but zero their values.

Similarly, when a query no longer produces certain metrics, the missing
metrics will be dropped by default. Queries can be configured to preserve
the missing metric's old value, or preserve the metric but zero the value.

Fixes https://github.com/braedon/prometheus-es-exporter/issues/38