### PR TITLE
Ipv6

### DIFF
--- a/prometheus_es_exporter/utils.py
+++ b/prometheus_es_exporter/utils.py
@@ -1,9 +1,12 @@
 import functools
 import logging
 import signal
+import socket
 import sys
 
 from collections import OrderedDict
+from prometheus_client import REGISTRY, start_http_server as orig_start_http_server
+from prometheus_client.exposition import _ThreadingSimpleServer
 
 log = logging.getLogger(__name__)
 
@@ -87,3 +90,12 @@ def nice_shutdown(shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
         return wrapper
 
     return decorator
+
+
+def start_http_server(port, addr='', registry=REGISTRY, ipv6=False):
+    # Monkeypatch the server class address family to support IPv6 if needed.
+    if ipv6:
+        _ThreadingSimpleServer.address_family = socket.AF_INET6
+
+    # Call original start_http_server()
+    orig_start_http_server(port, addr=addr, registry=registry)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='prometheus-es-exporter',
-    version='0.8.0.dev1',
+    version='0.8.0a1',
     description='Elasticsearch query Prometheus exporter',
     url='https://github.com/braedon/prometheus-es-exporter',
     author='Braedon Vickers',


### PR DESCRIPTION
Add support for serving metrics on IPv6 via the `--ipv6` CLI flag.

This branch is available as version `0.8.0a1` on pypi and dockerhub for testing purposes.