### PR TITLE
Command line configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,18 @@ To build a docker image directly from the git repo, run the following in the roo
 ```
 > sudo docker build -t <your repository name and tag> .
 ```
+
+To develop in a docker container file you should first build the container using
+```
+> sudo docker build -t exporter:latest
+```
+Then run (in the root of the git repo)
+```
+> sudo docker run --rm -it --name exporter --entrypoint bash $(pwd):/usr/src/app exporter:latest
+```
+This will mount all the files inside the container, so editing tests or application code will be synced live. You can run the tests with `python -m unittest`. You may need to run `pip install -e .` again after running the container if you get an error like
+```
+pkg_resources.DistributionNotFound: The 'prometheus-es-exporter' distribution was not found and is required by the application
+```
+
 Send me a PR if you have a change you want to contribute!

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ By default, it will bind to port 9206, query Elasticsearch on `localhost:9200` a
 ```
 Run with the `-h` flag to see details on all the available options.
 
-Note that all options can be set via environment variables. The environment variable names are prefixed with `ES_EXPORTER`, e.g. `ES_EXPORTER_BASIC_USER=fred` is equivalent to `--basic-user fred`. CLI options take precidence over environment variables.
-
+Note that all options can be set via environment variables. The environment variable names are prefixed with `ES_EXPORTER`, e.g. `ES_EXPORTER_BASIC_USER=fred` is equivalent to `--basic-user fred`. CLI options take precidence over environment variables. Command line options can also be set from a configuration file, by passing `--config FILE`. The format of the file should be [Configobj's unrepre mode](https://configobj.readthedocs.io/en/latest/configobj.html#unrepr-mode), so instead of `--basic-user fred` you could use a configuration file `config_file` with `basic-user="fred"` in it, and pass `--config config_file`. Command line and environment options will override the configuration file options. Configuration file options override default options. So the resolution order for a given option is: CLI > Environment > Configuration file > Default.
 
 See the provided [exporter.cfg](exporter.cfg) file for query configuration examples and explanation.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ By default, it will bind to port 9206, query Elasticsearch on `localhost:9200` a
 ```
 Run with the `-h` flag to see details on all the available options.
 
-Note that all options can be set via environment variables. The environment variable names are prefixed with `ES_EXPORTER`, e.g. `ES_EXPORTER_BASIC_USER=fred` is equivalent to `--basic-user fred`. CLI options take precidence over environment variables. Command line options can also be set from a configuration file, by passing `--config FILE`. The format of the file should be [Configobj's unrepre mode](https://configobj.readthedocs.io/en/latest/configobj.html#unrepr-mode), so instead of `--basic-user fred` you could use a configuration file `config_file` with `basic-user="fred"` in it, and pass `--config config_file`. Command line and environment options will override the configuration file options. Configuration file options override default options. So the resolution order for a given option is: CLI > Environment > Configuration file > Default.
+Note that all options can be set via environment variables. The environment variable names are prefixed with `ES_EXPORTER`, e.g. `ES_EXPORTER_BASIC_USER=fred` is equivalent to `--basic-user fred`. CLI options take precedence over environment variables.
+
+Command line options can also be set from a configuration file, by passing `--config FILE`. The format of the file should be [Configobj's unrepre mode](https://configobj.readthedocs.io/en/latest/configobj.html#unrepr-mode), so instead of `--basic-user fred` you could use a configuration file `config_file` with `basic-user="fred"` in it, and pass `--config config_file`. CLI options and environment variables take precedence over configuration files.
+
+CLI options, environment variables, and configuration files all override any default options. The full resolution order for a given option is: CLI > Environment > Configuration file > Default.
 
 See the provided [exporter.cfg](exporter.cfg) file for query configuration examples and explanation.
 
@@ -83,13 +87,9 @@ To build a docker image directly from the git repo, run the following in the roo
 > sudo docker build -t <your repository name and tag> .
 ```
 
-To develop in a docker container file you should first build the container using
+To develop in a docker container, first build the image, and then run the following in the root project directory:
 ```
-> sudo docker build -t exporter:latest
-```
-Then run (in the root of the git repo)
-```
-> sudo docker run --rm -it --name exporter --entrypoint bash $(pwd):/usr/src/app exporter:latest
+> sudo docker run --rm -it --name exporter --entrypoint bash -v $(pwd):/usr/src/app <your repository name and tag>
 ```
 This will mount all the files inside the container, so editing tests or application code will be synced live. You can run the tests with `python -m unittest`. You may need to run `pip install -e .` again after running the container if you get an error like
 ```

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -396,8 +396,6 @@ CONFIGPARSER_CONVERTERS = {
 @click_config_file.configuration_option()
 def cli(**options):
     """Export Elasticsearch query results to Prometheus."""
-    print(options)
-    return
     if options['basic_user'] and options['basic_password'] is None:
         click.BadOptionUsage('basic_user', 'Username provided with no password.')
     elif options['basic_user'] is None and options['basic_password']:

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -1,4 +1,5 @@
 import click
+import click_config_file
 import configparser
 import glob
 import json
@@ -392,9 +393,11 @@ CONFIGPARSER_CONVERTERS = {
               help='Detail level to log. (default: INFO)')
 @click.option('--verbose', '-v', default=False, is_flag=True,
               help='Turn on verbose (DEBUG) logging. Overrides --log-level.')
+@click_config_file.configuration_option()
 def cli(**options):
     """Export Elasticsearch query results to Prometheus."""
-
+    print(options)
+    return
     if options['basic_user'] and options['basic_password'] is None:
         click.BadOptionUsage('basic_user', 'Username provided with no password.')
     elif options['basic_user'] is None and options['basic_password']:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'click',
+        'click-config-file',
         'elasticsearch',
         'jog',
         'prometheus-client >= 0.6.0',


### PR DESCRIPTION
Using `click-config-file`, we can easily load all command line options from a file.

Also adding documentation for developing inside the docker container. This is another way to develop apart from creating a python virtualenv, or just installing into the system environment.

Closes #62 