### PR TITLE
Fixing new_value_dict initialisation when query-matched-metric drops

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='prometheus-es-exporter',
-    version='0.8.0.dev1',
+    version='0.8.0',
     description='Elasticsearch query Prometheus exporter',
     url='https://github.com/braedon/prometheus-es-exporter',
     author='Braedon Vickers',


### PR DESCRIPTION
Closes: https://github.com/braedon/prometheus-es-exporter/issues/76