### PR TITLE
Add concurrent query execution support

### DIFF
--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -436,8 +436,9 @@ CONFIGPARSER_CONVERTERS = {
                    'in filename order. '
                    'Can be absolute, or relative to the current working directory. '
                    '(default: ./config)')
-@click.option('--threads',
-              help='Enables concurrent query execution using the number of threads specified. If the number of threads is less than 1, throws an error.')
+@click.option('--threads', type=click.IntRange(min=1), default=1,
+              help='Enables concurrent query execution using the number of threads specified. '
+                   '(default: 1))
 @click.option('--cluster-health-disable', default=False, is_flag=True,
               help='Disable cluster health monitoring.')
 @click.option('--cluster-health-timeout', default=10.0,

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -438,7 +438,7 @@ CONFIGPARSER_CONVERTERS = {
                    '(default: ./config)')
 @click.option('--threads', type=click.IntRange(min=1), default=1,
               help='Enables concurrent query execution using the number of threads specified. '
-                   '(default: 1))
+                   '(default: 1)')
 @click.option('--cluster-health-disable', default=False, is_flag=True,
               help='Disable cluster health monitoring.')
 @click.option('--cluster-health-timeout', default=10.0,

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -521,11 +521,8 @@ def cli(**options):
                                    '--indices-stats-indices to be used.')
 
     executor = None
-    if options['threads']:
-        num_threads = int(options['threads'])
-        if num_threads < 1:
-            raise click.BadOptionUsage('threads',
-                                       '--threads must specify a number of threads greater than 0.')
+    num_threads = options['threads']
+    if num_threads > 1:
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=num_threads)
 
     log_handler = logging.StreamHandler()

--- a/prometheus_es_exporter/scheduler.py
+++ b/prometheus_es_exporter/scheduler.py
@@ -1,6 +1,5 @@
 import time
 import logging
-import concurrent.futures
 
 log = logging.getLogger(__name__)
 

--- a/prometheus_es_exporter/scheduler.py
+++ b/prometheus_es_exporter/scheduler.py
@@ -18,8 +18,8 @@ def schedule_job(scheduler, executor, interval, func, *args, **kwargs):
             except Exception:
                 log.exception('Error while running scheduled job.')
 
-        if executor != None:
-            executor.submit(lambda *args, **kwargs: run_func(func, *args, **kwargs), *args, **kwargs)
+        if executor is not None:
+            executor.submit(run_func, func, *args, **kwargs)
         else:
             run_func(func, *args, **kwargs)
 

--- a/prometheus_es_exporter/scheduler.py
+++ b/prometheus_es_exporter/scheduler.py
@@ -3,8 +3,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-
-def schedule_job(scheduler, interval, func, *args, **kwargs):
+def schedule_job(scheduler, executor, interval, func, *args, **kwargs):
     """
     Schedule a function to be run on a fixed interval.
 
@@ -12,10 +11,16 @@ def schedule_job(scheduler, interval, func, *args, **kwargs):
     """
 
     def scheduled_run(scheduled_time, *args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except Exception:
-            log.exception('Error while running scheduled job.')
+        def run_func(func, *args, **kwargs):
+            try:
+                func(*args, **kwargs)
+            except Exception:
+                log.exception('Error while running scheduled job.')
+
+        if executor != None:
+            executor.submit(lambda *args, **kwargs: run_func(func, *args, **kwargs), *args, **kwargs)
+        else:
+            run_func(func, *args, **kwargs)
 
         current_time = time.monotonic()
         next_scheduled_time = scheduled_time + interval

--- a/prometheus_es_exporter/utils.py
+++ b/prometheus_es_exporter/utils.py
@@ -52,7 +52,8 @@ def log_exceptions(exit_on_exception=False):
     return decorator
 
 
-def nice_shutdown(shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
+def nice_shutdown(executor=None,
+                  shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
     """
     Logs shutdown signals nicely.
 
@@ -64,6 +65,9 @@ def nice_shutdown(shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
     def sig_handler(signum, _):
         log.info('Received signal %(signal)s.',
                  {'signal': signal.Signals(signum).name})
+        # Finish ThreadPoolExecutor execution cleanly, if using threading.
+        if executor != None:
+            executor.shutdown()
         # Raise SystemExit to bypass (most) try/except blocks.
         sys.exit()
 

--- a/prometheus_es_exporter/utils.py
+++ b/prometheus_es_exporter/utils.py
@@ -52,8 +52,7 @@ def log_exceptions(exit_on_exception=False):
     return decorator
 
 
-def nice_shutdown(executor=None,
-                  shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
+def nice_shutdown(shutdown_signals=(signal.SIGINT, signal.SIGTERM)):
     """
     Logs shutdown signals nicely.
 
@@ -65,9 +64,7 @@ def nice_shutdown(executor=None,
     def sig_handler(signum, _):
         log.info('Received signal %(signal)s.',
                  {'signal': signal.Signals(signum).name})
-        # Finish ThreadPoolExecutor execution cleanly, if using threading.
-        if executor != None:
-            executor.shutdown()
+
         # Raise SystemExit to bypass (most) try/except blocks.
         sys.exit()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='prometheus-es-exporter',
-    version='0.12.0.dev1',
+    version='0.12.0',
     description='Elasticsearch query Prometheus exporter',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This commit adds the ability to concurrently execute queries to the exporter. If initialized with --threads NUM_THREADS, the exporter schedules queries to be executed by a ThreadPoolExecutor using up to that many threads.

I tested this locally against an Elasticsearch cluster, both with and without the --threads option. Using the --threads option, I verified that the queries executed concurrently, and also that the exception handling correctly logged to the console.