### PR TITLE
Add possibility to drop at an interval even if QueryOnMissing=preserve

### DIFF
--- a/exporter.cfg
+++ b/exporter.cfg
@@ -21,6 +21,9 @@ QueryOnError = drop
 # * drop - remove the metric.
 # * zero - keep the metric, but reset its value to 0.
 QueryOnMissing = drop
+# How often to drop the values even if missing was set to preserve?
+# Applied only when QueryOnMissing = preserve
+QueryOnMissingPreserveButDropAfterSecs = 0
 
 # Queries are defined in sections beginning with 'query_'.
 # Characters following this prefix will be used as a prefix for all metrics

--- a/prometheus_es_exporter/__init__.py
+++ b/prometheus_es_exporter/__init__.py
@@ -199,6 +199,10 @@ class QueryMetricCollector(object):
         for metric_dict in query_metrics.values():
             yield from gauge_generator(metric_dict)
 
+def drop_after(query_name):
+
+    log.info("Clearing the cache...")
+    METRICS_BY_QUERY[query_name] = {}
 
 def run_query(es_client, query_name, indices, query,
               timeout, on_error, on_missing):
@@ -597,18 +601,26 @@ def cli(**options):
                                           fallback='drop')
                 on_missing = config.getenum(section, 'QueryOnMissing',
                                             fallback='drop')
+                drop_after_missing_preserve = config.getfloat(section, 'QueryOnMissingPreserveButDropAfterSecs',
+                                            fallback=0)
 
                 queries[query_name] = (interval, timeout, indices, query,
-                                       on_error, on_missing)
+                                       on_error, on_missing, drop_after_missing_preserve)
 
         scheduler = sched.scheduler()
 
         if queries:
             for query_name, (interval, timeout, indices, query,
-                             on_error, on_missing) in queries.items():
+                             on_error, on_missing, drop_after_missing_preserve) in queries.items():
+                """ If drop after is set, setup a scheduler to clear the cache """
+                if on_missing == 'preserve' and drop_after_missing_preserve > 0:
+                    schedule_job(scheduler, executor, drop_after_missing_preserve,
+                                                 drop_after, query_name)
+
                 schedule_job(scheduler, executor, interval,
                              run_query, es_client, query_name, indices, query,
                              timeout, on_error, on_missing)
+
         else:
             log.error('No queries found in config file(s)')
             return


### PR DESCRIPTION
Hi,

I had a requirement where I had to select the method 'preserve' for missing, but could not pile up all the preserved metrics for a long time. 
This PR adds this flag to control the preserve duration and clears the cache after the configured interval.

Thanks,
Dipesh